### PR TITLE
Please merge this change into ain so that I can remove a local copy from the repo for my cef logging library.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,9 +38,15 @@ var Transport = {
         var client = dgram.createSocket('udp4');
         var self = this;
 
-        message = new Buffer('<' + (this.facility * 8 + severity) + '>' +
-            getDate() + ' ' + this.hostname + ' ' + 
+        if (this.concise == true) {
+            message = new Buffer('<' + (this.facility * 8 + severity) + '>' +
+            getDate() + ' ' + message);
+        } else {
+            message = new Buffer('<' + (this.facility * 8 + severity) + '>' +
+            getDate() + ' ' + this.hostname + ' ' +
             this.tag + '[' + process.pid + ']:' + message);
+        }
+
 
         client.send(message,
                     0,
@@ -73,9 +79,15 @@ var Transport = {
 
         return function(message, severity) {
             var client = dgram.createSocket('unix_dgram') ;
-            message = new Buffer('<' + (this.facility * 8 + severity) + '>' +
-                getDate() + ' ' + this.hostname + ' ' + 
-                this.tag + '[' + process.pid + ']:' + message);
+	        if (this.concise == true) {
+	            message = new Buffer('<' + (this.facility * 8 + severity) + '>' +
+	                      getDate() + ' ' + message);
+	        } else {
+	                message = new Buffer('<' + (this.facility * 8 + severity) + '>' +
+	                          getDate() + ' ' + this.hostname + ' ' +
+		                  this.tag + '[' + process.pid + ']:' + message);
+		    }
+
 
             client.send(message,
                         0,
@@ -198,6 +210,7 @@ SysLogger.getInstance = function() {
  *          - hostname  - {String}                  By default is require("os").hostname()
  *          - port      - {Number}                  Defaults to 514
  *          - transport - {Transport|String}        Defaults to Transport.UDP
+ *	    - concise	- {Boolean}		    Defaults to false
  */
 SysLogger.prototype.set = function(config) {
     config = config || {} ;
@@ -206,6 +219,7 @@ SysLogger.prototype.set = function(config) {
     this.setFacility(config.facility);
     this.setHostname(config.hostname);
     this.setPort(config.port);
+    this.setConcise(config.concise);
     if (config.hostname) {
         this.setTransport(Transport.UDP) ;
     } else {
@@ -214,6 +228,12 @@ SysLogger.prototype.set = function(config) {
     
     return this;
 };
+
+SysLogger.prototype.setConcise = function(concise)
+{
+    this.concise = concise || false;
+    return this;
+}
 
 SysLogger.prototype.setTransport = function(transport) {
     this.transport = transport || Transport.UDP;

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@ The `set` function takes one argument, a configuration object which can contain 
  * hostname - defaults to require('os').hostname()
  * port - defaults to 514
  * transport - defaults to 'UDP', can also be 'file'
+ * concise - defaults to true
 
 All of these are optional. If you provide a `hostname` transport is automatically set to UDP
 
@@ -116,6 +117,8 @@ your messages.
     21  local5  local use 5
     22  local6  local use 6
     23  local7  local use 7
+
+If `concise` is true, the tag, filename, and supplied hostname will not be written out as part of the entry.
 
 You can set the `facility` by `String` or `Number`:
 


### PR DESCRIPTION
The concise format allows for control over the format of the message
for compatibility with specific syslog format requirements.

Defaults to false, controlled by passing { concise : true } as part of call to set.

Changes message format to:
Jan 31 10:56:35 127.0.0.1 : yboily-mac This is a concise message, TORONTO

Jan 31 10:56:35 127.0.0.1 yboily-mac /Users/yvanboily/node_modules/ain2/index.js[50651]: This is not a concise message, TORONTO
