### PR TITLE
Error: Unknown OS Type: FreeBSD

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ var Transport = {
 
         switch(require('os').type()) {
             case 'Darwin': 
+            case 'FreeBSD':
                 logTarget = '/var/run/syslog' ;
                 break ;
 


### PR DESCRIPTION
Set FreeBSD to use same log device as Darwin OS
