### PR TITLE
Fixed high-concurrency crashes when using UDP transport

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,14 +78,17 @@ var Transport = {
 
             case 'Linux':
                 logTarget = '/dev/log' ;
-                break ;
-
+                break ;           
             default:
-                throw new Error('Unknown OS Type: ' + require('os').type()) ;
-
+                logTarget = false ;
+                break ;
         }
 
         return function(message, severity) {
+            if (false === logTarget) {
+                throw new Error('Unknown OS Type: ' + require('os').type()) ;
+            }
+
             var client = dgram.createSocket('unix_dgram') ;
             var syslogMessage = this.composerFunction(message, severity);
             client.send(syslogMessage,


### PR DESCRIPTION
When using the UDP transport, this library creates a new socket for each "log" call (which it then closes after the data is written to the socket). 

This can be problematic under high concurrency situations because you could potentially have at a given time hundreds or thousands of concurrent log calls, each trying to create a new UDP socket. 

I was able to crash our node server consistently due to this problem, by using APIB (http://code.google.com/p/apib/) with high concurrency levels.

My fix is simple, as it aims to re-use the same UDP socket as much as possible, and after 1 second of it not being used, the socket is closed. 
