### PR TITLE
Added support for unix-dgram transport for node > 0.7 and udp6

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./index",
   "author": "Alexander Dorofeev <aka.spin@gmail.com>",
   "scripts": {
-      "test": "./node_modules/.bin/mocha test/**/*.spec.js"
+    "test": "./node_modules/.bin/mocha test/**/*.spec.js"
   },
   "contributors": [
     {
@@ -49,5 +49,8 @@
   "devDependencies": {
     "mocha": "~1.12.0",
     "chai": "~1.7.2"
+  },
+  "dependencies": {
+    "unix-dgram": "0.0.2"
   }
 }

--- a/test/unix.spec.js
+++ b/test/unix.spec.js
@@ -1,0 +1,29 @@
+var unixDgram = require('unix-dgram');
+var should = require('chai').should();
+var ain = require('../index');
+var fs = require('fs');
+
+describe('unix dgram', function(){
+    var server;
+    var callback;
+    var logger = new ain({address: __dirname + '/socket', transport: 'unix_dgram'});
+    before(function(done){
+        server = unixDgram.createSocket('unix_dgram', function(msg, rinfo){
+            if (callback) callback(msg);
+        });
+        server.bind(__dirname + '/socket');
+        setTimeout(done, 1000); // give the socket time to open
+    });
+    after(function(){
+        server.close();
+        try{fs.unlinkSync(__dirname + '/socket'); } catch(e){};
+    });
+    it('can send a unix dgram buffer', function(done){
+        logger.log('hello world');
+        callback = function(msg){
+            msg.should.be.an.instanceof(Buffer);
+            msg.toString().should.contain('hello world');
+            done();
+        }
+    });
+});


### PR DESCRIPTION
I'm using unix-dgram from Ben Noordhuis to get the support for unix dgrams > 0.7.

The SysLogger.prototype.transport had to be refactored to be accepting strings instead of the function in order to accept udp4, udp6, and unix_dgram.

It accepts the address property in the config as the path to the socket.  Its a little misnamed in that case, but LMK if you want to change the PR.

An integration test was also added to support this.
