### PR TITLE
Change default getDate() to use Date.toISOString()

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,18 +399,11 @@ SysLogger.prototype.assert = function(expression) {
 };
 
 /**
- * Get current date in syslog format. Thanks https://github.com/kordless/lodge
+ * Get current date in syslog format.
  * @returns {String}
  */
 SysLogger.prototype.getDate = function() {
-    var dt = new Date();
-    var hours = this.leadZero(dt.getUTCHours());
-    var minutes = this.leadZero(dt.getUTCMinutes());
-    var seconds = this.leadZero(dt.getUTCSeconds());
-    var month = this.leadZero((dt.getUTCMonth() + 1));
-    var day = this.leadZero(dt.getUTCDate());
-    var year = dt.getUTCFullYear();
-    return year+'-'+month+'-'+day+' '+hours+':'+minutes+':'+seconds;
+    return new Date().toISOString();
 }
 
 SysLogger.prototype.leadZero = function(n) {


### PR DESCRIPTION
This patch improves original timestamp by providing a microseconds resolution. Also reduces code by utilizing native method.

From MDN:

The toISOString() method returns a string in ISO format (ISO 8601 Extended Format), which can be described as follows: YYYY-MM-DDTHH:mm:ss.sssZ. The timezone is always UTC as denoted by the suffix "Z".

This is exactly the format required by the syslog protocol: http://www.syslog.cc/ietf/drafts/draft-ietf-syslog-protocol-15.txt
