### PR TITLE
Temporary fix to node 0.11.x clustering problems with UDP.

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,15 @@ var getSocket = function (type) {
 
         socket.on('error', socketErrorHandler)
 
+		// HACK: On Node v0.11.x bind the socket to ensure that it works when clustering
+		// THis should be a temporary fix until node fixes the cluster module
+		if (/^v0\.11\..*$/.test(process.version)) {
+			socket.bind({
+				port: 0,
+				exclusive: true
+			})
+		}
+
     }
 
     ++socketUsers

--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "chai": "~1.7.2"
   },
   "optionalDependencies": {
-    "unix-dgram": "0.0.5"
+    "unix-dgram": "0.1.1"
   }
 }


### PR DESCRIPTION
Probably fixes #24 although this is a temporary hack and only works on node 0.11.