### PR TITLE
Bump unix-dgram version to 2.0.2 and add ^

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "chai": "~1.7.2"
   },
   "optionalDependencies": {
-    "unix-dgram": "0.2.3"
+    "unix-dgram": "^2.0.2"
   }
 }


### PR DESCRIPTION
Dependency `unix-dgram` fails to compile on node v10.0.0.

`unix-dgram` has fix already for this, so this pull request bumps the version.

All tests seem to pass.