### PR TITLE
Updated unix-dgram

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ain2",
   "description": "Syslog logging for node.js. Continuation of ain",
-  "version": "2.0.0",
+  "version": "3.0.1",
   "main": "./index",
   "author": "Alexander Dorofeev <aka.spin@gmail.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "bugs": {
     "url": "http://github.com/phuesler/ain/issues"
   },
-  "license" : "MIT",
+  "license": "MIT",
   "licenses": [
     {
       "type": "MIT",
@@ -56,6 +56,6 @@
     "chai": "~1.7.2"
   },
   "optionalDependencies": {
-    "unix-dgram": "^2.0.2"
+    "unix-dgram": "^2.0.3"
   }
 }


### PR DESCRIPTION
Installation is failing for node 12.
unix-dgram [fixed](https://github.com/bnoordhuis/node-unix-dgram/issues/49) it in 2.0.3.